### PR TITLE
Use absolute imports

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,6 +13,15 @@
           {
             "extensions": [".css"]
           }
+        ],
+        [
+          "module-resolver",
+          {
+            "root": ["./"],
+            "alias": {
+              "components": "./components"
+            }
+          }
         ]
       ]
     },
@@ -31,6 +40,15 @@
           {
             "extensions": [".css"]
           }
+        ],
+        [
+          "module-resolver",
+          {
+            "root": ["./"],
+            "alias": {
+              "components": "./components"
+            }
+          }
         ]
       ]
     },
@@ -48,6 +66,15 @@
           "inline-import",
           {
             "extensions": [".css"]
+          }
+        ],
+        [
+          "module-resolver",
+          {
+            "root": ["./"],
+            "alias": {
+              "components": "./components"
+            }
           }
         ]
       ]

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@fortawesome/react-fontawesome": "^0.0.17",
     "axios": "^0.17.1",
     "babel-plugin-inline-import": "^2.0.6",
+    "babel-plugin-module-resolver": "^3.0.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-define": "^1.2.0",
     "enzyme": "^3.3.0",

--- a/pages/listings/show.js
+++ b/pages/listings/show.js
@@ -2,17 +2,17 @@ import { Component } from 'react'
 import MediaQuery from 'react-responsive'
 import Head from 'next/head'
 
-import { mainListingImage } from '../../utils/image_url'
-import { isAuthenticated, isAdmin, getCurrentUserId } from '../../lib/auth'
-import { getListing } from '../../services/listing-api'
-import { createInterest } from '../../services/interest-api'
+import { mainListingImage } from 'utils/image_url'
+import { isAuthenticated, isAdmin, getCurrentUserId } from 'lib/auth'
+import { getListing } from 'services/listing-api'
+import { createInterest } from 'services/interest-api'
 
-import Layout from '../../components/main-layout'
-import ListingHeader from '../../components/listings/listing/header'
-import ListingMainContent from '../../components/listings/listing/main-content'
-import ListingFooter from '../../components/listings/listing/listing-footer'
-import MapContainer from '../../components/map-container'
-import Popup from '../../components/popup'
+import Layout from 'components/main-layout'
+import ListingHeader from 'components/listings/listing/header'
+import ListingMainContent from 'components/listings/listing/main-content'
+import ListingFooter from 'components/listings/listing/listing-footer'
+import MapContainer from 'components/map-container'
+import Popup from 'components/popup'
 
 export default class Listing extends Component {
   state = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -649,6 +649,16 @@ babel-plugin-module-resolver@2.7.1:
     glob "^7.1.1"
     resolve "^1.2.0"
 
+babel-plugin-module-resolver@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.0.0.tgz#a2fe5b97f7b809a8bbac18beada0a94d45987c63"
+  dependencies:
+    find-babel-config "^1.1.0"
+    glob "^7.1.2"
+    pkg-up "^2.0.0"
+    reselect "^3.0.1"
+    resolve "^1.4.0"
+
 babel-plugin-react-require@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-require/-/babel-plugin-react-require-3.0.0.tgz#2e4e7b4496b93a654a1c80042276de4e4eeb20e3"
@@ -2551,7 +2561,7 @@ finalhandler@1.1.0:
     statuses "~1.3.1"
     unpipe "~1.0.0"
 
-find-babel-config@^1.0.1:
+find-babel-config@^1.0.1, find-babel-config@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.1.0.tgz#acc01043a6749fec34429be6b64f542ebb5d6355"
   dependencies:
@@ -4929,7 +4939,7 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-pkg-up@2.0.0:
+pkg-up@2.0.0, pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
   dependencies:
@@ -5643,6 +5653,10 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
@@ -5655,7 +5669,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.2.0:
+resolve@^1.2.0, resolve@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:


### PR DESCRIPTION
Install babel plugin to enable "absolute" imports, cleaning up and normalizing import paths.