### PR TITLE
Improve layout in mobile home page

### DIFF
--- a/components/home/search.js
+++ b/components/home/search.js
@@ -268,6 +268,7 @@ export default class HomeSearch extends Component {
             width: 100vw;
             h1 {
               font-weight: 400;
+              margin-top: 20px;
               max-width: calc(100vw - 60px);
             }
           }
@@ -275,6 +276,7 @@ export default class HomeSearch extends Component {
           div.search {
             background: transparent;
             border: none;
+            margin-top: 20px;
             width: calc(100vw - 40px);
             > div {
               flex-direction: column;

--- a/components/home/selling-points.js
+++ b/components/home/selling-points.js
@@ -59,10 +59,16 @@ export default class HomeSellingPoints extends Component {
 
         @media ${mobileMedia} {
           div.container {
+            align-items: center;
             display: flex;
             flex-direction: column;
             width: 100vw;
           }
+
+          h1 {
+              max-width: calc(100vw - 60px);
+          }
+
           div.container div {
             align-items: center;
             flex-direction: column;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,11 +1,11 @@
-import { Component } from 'react'
+import {Component} from 'react'
 import Head from 'next/head'
 import Link from 'next/link'
 
 import * as colors from 'constants/colors'
-import { getFeaturedListings } from 'services/listing-api'
-import { getNeighborhoods } from 'services/neighborhood-api'
-import { isAuthenticated } from 'lib/auth'
+import {getFeaturedListings} from 'services/listing-api'
+import {getNeighborhoods} from 'services/neighborhood-api'
+import {isAuthenticated} from 'lib/auth'
 import Layout from 'components/main-layout'
 import HomeSearch from 'components/home/search'
 import HomeListings from 'components/home/listings'
@@ -47,7 +47,7 @@ export default class MyPage extends Component {
   }
 
   render () {
-    const { authenticated, listings, neighborhoods } = this.props
+    const {authenticated, listings, neighborhoods} = this.props
     const seoImg = 'http://res.cloudinary.com/emcasa/image/upload/v1517101014/emcasa-fb-2018-01-27_ntxnrz.jpg'
     const seoTitle = 'EmCasa: Apartamentos, Casas e Imóveis à venda e para comprar ou anunciar no Rio de Janeiro'
     const seoDescription = 'Imobiliária Digital com Tour Virtual em 3D, assistência jurídica e comissões de 3%. Encontre Imóveis, Casas e Apartamentos novos e usados para compra, venda, anuncio ou avaliação em Ipanema, Leblon, Copacabana, Botafogo, Flamengo, Lagoa e toda Zona Sul do Rio de Janeiro, RJ.'


### PR DESCRIPTION
Couldn't easily and quickly show changes in screenshots, something weird with my Mac Preview.

1. Reduced space around main headline in home: more of the filter form visible "above the fold".
2. Fixed "Imobilária do jeito que deve ser" max-width...was touching the border of iPhone 6.
3. More Eslint fixes