### PR TITLE
Send JWT in get listing request.

### DIFF
--- a/pages/listings/show.js
+++ b/pages/listings/show.js
@@ -1,6 +1,6 @@
 import {Component} from 'react'
 
-import {isAuthenticated, isAdmin, getCurrentUserId} from 'lib/auth'
+import {isAuthenticated, isAdmin, getCurrentUserId, getJwt} from 'lib/auth'
 import {getListing} from 'services/listing-api'
 import {createInterest} from 'services/interest-api'
 
@@ -28,9 +28,10 @@ export default class Listing extends Component {
   }
 
   static async getInitialProps(context) {
+    const jwt = getJwt(context)
     const {id} = context.query
 
-    const res = await getListing(id)
+    const res = await getListing(id, jwt)
 
     if (res.data.errors) {
       this.setState({errors: res.data.errors})

--- a/services/listing-api.js
+++ b/services/listing-api.js
@@ -81,9 +81,9 @@ export const getFeaturedListings = async (query) => {
   }
 }
 
-export const getListing = async (id) => {
+export const getListing = async (id, jwt) => {
   try {
-    const response = await get('/listings/' + id)
+    const response = await get('/listings/' + id, jwt)
     return response
   } catch (error) {
     return error.response && error.response.status === 422


### PR DESCRIPTION
- Send JWT with the getListing request so we can record user based listing view