### PR TITLE
Add two prettier rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,46 +1,49 @@
 module.exports = {
-  "env": {
-    "browser": true,
-    "commonjs": true,
-    "es6": true
+  env: {
+    browser: true,
+    commonjs: true,
+    es6: true,
   },
-  "extends": [
-    "eslint:recommended"
-  ],
-  "parser": "babel-eslint",
-  "parserOptions": {
-    "ecmaFeatures": {
-      "experimentalObjectRestSpread": true,
-      "jsx": true
+  extends: ['eslint:recommended'],
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaFeatures: {
+      experimentalObjectRestSpread: true,
+      jsx: true,
     },
-    "sourceType": "module"
+    sourceType: 'module',
   },
-  "plugins": [
-    "react",
-    "prettier"
-  ],
-  "rules": {
-    "prettier/prettier": ["error", {
-      "bracketSpacing": false,
-      "singleQuote": true,
-      "semi": false
-    }],
-    "array-bracket-spacing": [2, "never"],
-    "comma-dangle": ["error", {
-        "arrays": "always-multiline",
-        "objects": "never",
-        "imports": "never",
-        "exports": "never",
-        "functions": "ignore"
-    }],
-    "indent": ["error", 2],
-    "linebreak-style": ["error", "unix"],
-    "object-curly-spacing": ["error", "never"],
-    "quotes": ["error", "single"],
-    "react/jsx-uses-vars": 1,
-    "semi": ["error", "never"],
+  plugins: ['react', 'prettier'],
+  rules: {
+    'prettier/prettier': [
+      'error',
+      {
+        bracketSpacing: false,
+        singleQuote: true,
+        semi: false,
+        arrowParens: 'always',
+        trailingComma: 'es5',
+      },
+    ],
+    'array-bracket-spacing': [2, 'never'],
+    'comma-dangle': [
+      'error',
+      {
+        arrays: 'always-multiline',
+        objects: 'never',
+        imports: 'never',
+        exports: 'never',
+        functions: 'ignore',
+      },
+    ],
+    indent: ['error', 2],
+    'linebreak-style': ['error', 'unix'],
+    'object-curly-spacing': ['error', 'never'],
+    quotes: ['error', 'single'],
+    'react/jsx-uses-vars': 1,
+    semi: ['error', 'never'],
   },
-  "globals": {
-    "process": true,
+  globals: {
+    process: true,
   },
-};
+}


### PR DESCRIPTION
Adds 2 prettier rules:

1. enforce parens for fat arrow function arguments, always
2. use es5 as criterion for comma dangles

Ran prettier on `.eslintrc` itself.