### PR TITLE
Try to improve interplay between eslint and prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     commonjs: true,
     es6: true,
   },
-  extends: ['eslint:recommended'],
+  extends: ['prettier'],
   parser: 'babel-eslint',
   parserOptions: {
     ecmaFeatures: {
@@ -22,7 +22,7 @@ module.exports = {
         singleQuote: true,
         semi: false,
         arrowParens: 'always',
-        trailingComma: 'es5',
+        trailingComma: 'none',
       },
     ],
     'array-bracket-spacing': [2, 'never'],

--- a/components/home/Search/index.js
+++ b/components/home/Search/index.js
@@ -11,7 +11,7 @@ import Container, {
   Search,
   Neighborhoods,
   Magnifier,
-  MobileMagnifier,
+  MobileMagnifier
 } from './styles'
 
 export default class HomeSearch extends Component {
@@ -76,7 +76,7 @@ export default class HomeSearch extends Component {
       ReactGA.event({
         category: 'Search',
         label: 'User search from Home',
-        action: 'homeSearch',
+        action: 'homeSearch'
       })
 
       Router.push(`/listings/index?${params}`, `/imoveis?${params}`).then(() =>
@@ -90,7 +90,7 @@ export default class HomeSearch extends Component {
   }
 
   render() {
-    const {quartos, preco_minimo, preco_maximo, bairros} = this.state
+    const {bairros} = this.state
     const {neighborhoods} = this.props
     const neighborhoodOptions = filterOptions.neighborhoodOptions(neighborhoods)
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "babel-eslint": "^8.2.1",
     "eslint": "^4.16.0",
+    "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.0",
     "eslint-plugin-react": "^7.6.0",
     "prettier": "1.10.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2315,6 +2315,12 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-config-prettier@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz#5ecd65174d486c22dff389fe036febf502d468a3"
+  dependencies:
+    get-stdin "^5.0.1"
+
 eslint-plugin-prettier@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz#33e4e228bdb06142d03c560ce04ec23f6c767dd7"
@@ -2836,6 +2842,10 @@ get-pkg-repo@^1.0.0:
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
+
+get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
 get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
I ended up reverting the rule for multiline comma-dangles, to never.

So far this was the only way I could make prettier and eslint not lead me to a cycle of asking me to take commas in and out eternally.