### PR TITLE
Render fallback image full width in listings/show

### DIFF
--- a/components/listings/show/Header/index.js
+++ b/components/listings/show/Header/index.js
@@ -15,7 +15,7 @@ export default class ListingHeader extends Component {
       handleOpen3DTour,
     } = this.props
 
-    const {matterport_code} = listing
+    const {matterport_code, images} = listing
     const src = `https://my.matterport.com/show/?m=${matterport_code}`
 
     return (
@@ -31,7 +31,10 @@ export default class ListingHeader extends Component {
             allowFullScreen
           />
         ) : (
-          <img className="image" src={mainListingImage(listing)} />
+          <div
+            className="image"
+            style={{backgroundImage: `url(${mainListingImage(images)})`}}
+          />
         )}
 
         <div className="top-right">

--- a/components/listings/show/Header/styles.js
+++ b/components/listings/show/Header/styles.js
@@ -11,8 +11,11 @@ export default styled.header`
     position: absolute;
   }
 
-  .image {
-    max-height: 100%;
+  div.image {
+    background-position: center;
+    background-size: cover;
+    height: 100%;
+    width: 100%;
     margin: 0 auto;
     display: block;
   }


### PR DESCRIPTION
# After

![image](https://user-images.githubusercontent.com/380816/36453169-e4f39d0a-1675-11e8-8b6c-2768096d8bee.png)

# Before 

![image](https://user-images.githubusercontent.com/380816/36453174-e9efe908-1675-11e8-8ef2-086adff739c6.png)
