### PR TITLE
Resize map marker fonts

### DIFF
--- a/components/shared/Map/Marker/styles.js
+++ b/components/shared/Map/Marker/styles.js
@@ -7,10 +7,10 @@ export default styled.div`
   border-radius: 4px;
   box-shadow: 1px 3px 6px rgba(0, 0, 0, 0.3);
   color: white;
-  font-size: 16px;
+  font-size: 12px;
   font-weight: 400;
   margin-top: -6px;
-  padding: 4px 10px 6px;
+  padding: 3px 6px 4px;
   position: absolute;
   transform: translate(-50%, -100%);
   &:hover {


### PR DESCRIPTION
# After

![image](https://user-images.githubusercontent.com/380816/37714707-fb30c068-2cf8-11e8-9c36-f02a279dcd25.png)

# Before

![image](https://user-images.githubusercontent.com/380816/37714720-01cd6e08-2cf9-11e8-9253-6ddb9ccf23dd.png)
