### PR TITLE
Update header links

### DIFF
--- a/__tests__/components/header.test.js
+++ b/__tests__/components/header.test.js
@@ -7,7 +7,7 @@ describe('Header', () => {
   it('should render unauthenticated', () => {
     const header = shallow(<Header />)
 
-    expect(header.find(Link)).toHaveLength(5)
+    expect(header.find(Link)).toHaveLength(6)
 
     expect(
       header
@@ -20,10 +20,17 @@ describe('Header', () => {
 
     expect(
       header
+        .find('[href="/listings"]')
+        .find('a')
+        .text()
+    ).toEqual('Compre')
+
+    expect(
+      header
         .find('[href="/listings/new"]')
         .find('a')
         .text()
-    ).toEqual('Venda seu Imóvel')
+    ).toEqual('Venda')
 
     expect(
       header
@@ -41,7 +48,7 @@ describe('Header', () => {
   it('should render authenticated', () => {
     const header = shallow(<Header authenticated={true} isAdmin={true} />)
 
-    expect(header.find(Link)).toHaveLength(4)
+    expect(header.find(Link)).toHaveLength(5)
 
     expect(
       header
@@ -71,7 +78,7 @@ describe('Header', () => {
         .find('[href="/listings/new"]')
         .find('a')
         .text()
-    ).toEqual('Venda seu Imóvel')
+    ).toEqual('Venda')
 
     expect(header.find('[href="/auth/logout"]').exists()).toEqual(true)
     expect(header.find('[href="/login"]').exists()).toEqual(false)

--- a/components/shared/Shell/Header/index.js
+++ b/components/shared/Shell/Header/index.js
@@ -40,8 +40,12 @@ export default class Header extends Component {
         <Button onClick={this.toggleMobileNavVisibility}>☰</Button>
 
         <Nav visible={isMobileNavVisible}>
-          <Link href="/listings/new" as="/imoveis/adicionar">
-            <a>Venda seu Imóvel</a>
+          <Link href="/listings" as="/imoveis" prefetch>
+            <a>Compre</a>
+          </Link>
+
+          <Link href="/listings/new" as="/imoveis/adicionar" prefetch>
+            <a>Venda</a>
           </Link>
 
           <Link href="/indique">


### PR DESCRIPTION
* Add link to `Buy` 
* Use just the main verbs, `Buy` and `Sell`, to reduce cognitive rationalization to clicking, therefore inviting users to know more about EmCasa.

# After

![image](https://user-images.githubusercontent.com/380816/37874765-8c244ef4-300b-11e8-85b5-705dee28b323.png)

# Before

![image](https://user-images.githubusercontent.com/380816/37874767-941660c0-300b-11e8-8dcc-70a75ec5c57e.png)
