### PR TITLE
Sitemap & Cypress fixes

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,7 @@
 {
   "projectId": "w9uphs",
   "baseUrl": "http://localhost:3000/",
+  "videoRecording": false,
   "env": {
     "apiUrl": "http://localhost:4000"
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "next build",
     "start": "node server.js -p $PORT",
     "test":
-      "jest && yarn build && TEST=cypress start-server-and-test start http://localhost:3000/login cy:run",
+      "jest && TEST=cypress start-server-and-test dev http://localhost:3000/login cy:run",
     "heroku-postbuild": "npm run build",
     "cy:open": "cypress open",
     "cy:run": "cypress run"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       "jest && yarn build && TEST=cypress start-server-and-test start http://localhost:3000/login cy:run",
     "heroku-postbuild": "npm run build",
     "cy:open": "cypress open",
-    "cy:run": "cypress run --record --key cc8e33f0-d280-48fb-981e-34051f56acc0"
+    "cy:run": "cypress run"
   },
   "dependencies": {
     "@fortawesome/fontawesome": "^1.1.2",

--- a/server.js
+++ b/server.js
@@ -148,18 +148,5 @@ const startServer = () => {
       process.exit(1)
     })
 }
-
-buildSitemap()
-  .then((response) => {
-    console.log(response)
-    startServer()
-  })
-  .catch((e) => {
-    console.log(
-      `The following error has ocurred while trying to build sitemap: ${
-        e.message
-      }`
-    )
-  })
-
+startServer()
 module.exports = startServer

--- a/server.js
+++ b/server.js
@@ -130,8 +130,25 @@ const startServer = () => {
         const parsedUrl = parse(req.url, true)
         const rootStaticFiles = ['/robots.txt', '/sitemap.xml']
         if (rootStaticFiles.indexOf(parsedUrl.pathname) > -1) {
-          const path = join(__dirname, 'static', parsedUrl.pathname)
-          app.serveStatic(req, res, path)
+          if (parsedUrl.pathname.indexOf('sitemap') > -1) {
+            buildSitemap()
+              .then((response) => {
+                console.log(response)
+                const path = join(__dirname, 'static', parsedUrl.pathname)
+                app.serveStatic(req, res, path)
+              })
+              .catch((e) => {
+                console.log(
+                  `The following error has ocurred while trying to build sitemap: ${
+                    e.message
+                  }`
+                )
+                app.render(req, res, '/', req.query)
+              })
+          } else {
+            const path = join(__dirname, 'static', parsedUrl.pathname)
+            app.serveStatic(req, res, path)
+          }
         } else {
           return handle(req, res)
         }


### PR DESCRIPTION
## Changes that were made in this PR

1. Cypress are not recording videos anymore
2. Cypress are not building the app before testing, the running time decreased a lot
3. Cypress will not stop if the server has already started, for example, if the port 3000 is being used
4. The sitemap is not generated on server start process anymore, it will only be generated when requested on route `/sitemap.xml`

