### PR TITLE
Add fallback to edge rect property

### DIFF
--- a/components/shared/InfiniteScroll/index.js
+++ b/components/shared/InfiniteScroll/index.js
@@ -24,7 +24,7 @@ export default class InfiniteScroll extends Component {
   get footerViewportDistance() {
     if (!this.footer) return null
     const rect = this.footer.getBoundingClientRect()
-    return rect.y - window.innerHeight
+    return (rect.y || rect.bottom) - window.innerHeight
   }
 
   shouldTriggerLoad = () => {

--- a/components/shared/InfiniteScroll/index.js
+++ b/components/shared/InfiniteScroll/index.js
@@ -4,6 +4,7 @@ import Link from 'next/link'
 
 import Container, {Footer} from './styles'
 import {withRouter} from 'next/router'
+import {getY} from 'utils/polyfills/bounding-rect'
 
 @withRouter
 export default class InfiniteScroll extends Component {
@@ -24,7 +25,7 @@ export default class InfiniteScroll extends Component {
   get footerViewportDistance() {
     if (!this.footer) return null
     const rect = this.footer.getBoundingClientRect()
-    return (rect.y || rect.bottom) - window.innerHeight
+    return getY(rect) - window.innerHeight
   }
 
   shouldTriggerLoad = () => {

--- a/utils/polyfills/bounding-rect.js
+++ b/utils/polyfills/bounding-rect.js
@@ -1,0 +1,3 @@
+// This is needed because Edge does not implement a y property on getBoundingClientRect:
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect
+export const getY = (rect) => rect.y || rect.bottom


### PR DESCRIPTION
`getBoundingClientRect()`on Edge does not have `y` property, the name is `bottom`.
Because of this the calculation for infinite scroll was returning NaN and the application was not loading more listings.
This PR fixes this error adding Edge fallback.