### PR TITLE
Fine tune breadcrumb in pages/listings/show

### DIFF
--- a/components/shared/Common/Breadcrumb/styles.js
+++ b/components/shared/Common/Breadcrumb/styles.js
@@ -12,7 +12,7 @@ export default styled.ul`
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  margin: 20px auto 0;
+  margin: 35px auto 0;
   padding-left: 20px;
   padding-right: 20px;
 
@@ -53,8 +53,10 @@ export const Path = styled.li`
 
   :not(:first-of-type) {
     :before {
-      content: '>';
-      margin: 0 3px;
+      content: '›';
+      font-size: 14px;
+      margin: 0 5px;
+      position: relative;
     }
   }
 `

--- a/pages/listings/show.js
+++ b/pages/listings/show.js
@@ -171,6 +171,10 @@ class Listing extends Component {
       interestForm
     } = this.state
 
+    const roomInformationForPath = listing.rooms
+      ? ` de ${listing.rooms} dormitórios`
+      : ''
+
     const paths = [
       {name: 'Comprar Imóvel', href: '/listings', as: '/imoveis'},
       {
@@ -179,7 +183,7 @@ class Listing extends Component {
         as: `/imoveis?bairros=${listing.address.neighborhood}`
       },
       {
-        name: `${listing.type} de ${listing.rooms} dormitórios`,
+        name: listing.type + roomInformationForPath,
         href: `${url.pathname}?id=${listing.id}`,
         as: url.asPath
       }


### PR DESCRIPTION
Use `›` instead of `>` for the separator.

Allow for listings with `null` rooms.

# After

![image](https://user-images.githubusercontent.com/380816/39069495-4fb397c6-44b6-11e8-9907-ec2c0fe8d53c.png)
