### PR TITLE
Show garage_spots as zero if null in backend

### DIFF
--- a/components/listings/show/Body/Card/index.js
+++ b/components/listings/show/Body/Card/index.js
@@ -44,7 +44,7 @@ export default class ListingCard extends React.Component {
           </div>
           <div>
             <span>N° Vagas</span>
-            <span>{garage_spots}</span>
+            <span>{garage_spots || 0}</span>
           </div>
           <div>
             <span>Andar</span>


### PR DESCRIPTION
# After

![image](https://user-images.githubusercontent.com/380816/39434294-75eb5cb4-4c98-11e8-95c2-78d8bc1eb7e4.png)

Before, it showed nothing on the right column.